### PR TITLE
Make sure keep previous errors

### DIFF
--- a/src/sdk/api/index.js
+++ b/src/sdk/api/index.js
@@ -96,8 +96,9 @@ function sendCallback () {
     // Before sending the callback.
     if (includesAllIds) {
         const data = responses.reduce((formData, response) => {
-          formData = { ...formData, ...response.data };
-          return formData;
+          const {errors, ...data} = formData;
+          const {errors: fieldErrors, ...fieldData} = response.data;
+          return {...data, ...fieldData, errors: {...errors, ...fieldErrors}};
         }, {});
         // Reset the responses.
         responses = []
@@ -142,7 +143,7 @@ function createIframeProxy (field, target) {
         fields: fieldsObj,
         service: service
     }, '*');
-    
+
     onLoadCounter++
     if (onLoadCounter === fields.length && onLoadCallback) {
         onLoadCallback()()

--- a/src/sdk/api/index.js
+++ b/src/sdk/api/index.js
@@ -98,7 +98,12 @@ function sendCallback () {
         const data = responses.reduce((formData, response) => {
           const {errors, ...data} = formData;
           const {errors: fieldErrors, ...fieldData} = response.data;
-          return {...data, ...fieldData, errors: {...errors, ...fieldErrors}};
+          const newData = {...data, ...fieldData};
+          const allErrors = {...errors, ...fieldErrors};
+          if (Object.keys(allErrors).length > 0) {
+            newData.errors = allErrors;
+          }
+          return newData;
         }, {});
         // Reset the responses.
         responses = []


### PR DESCRIPTION
We need to make sure destruct the errors object and merge them with the one from the field else response.data.errors override formData.errors and we only get the last error